### PR TITLE
Make compatible with Minimal-printf

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -3,13 +3,13 @@
 Examples are tested using tool [htrun](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests) and templated print log. 
 
 To run the test, use following command after you build the example:
-
-This assumes that example compiled with `GCC_ARM` and target `K64F`(DUT) with a mount point of `D:` and a serial port on `COM4`
-
+```bash
+$ mbedhtrun -d <MOUNT_POINT> -p <SERIAL_PORT> -m <TARGET> -f ./BUILD/<TARGET>/<TOOLCHAIN>/mbed-os-example-crash-reporting.bin --compare-log tests/crash-reporting.log
 ```
-mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\mbed-os-example-crash-reporting.bin --compare-log tests\crash-reporting.log
+For example:
+```bash
+$ mbedhtrun -d /media/user01/DAPLINK -p /dev/ttyACM0 -m K64F -f ./BUILD/K64F/GCC_ARM/mbed-os-example-crash-reporting.bin --compare-log tests/crash-reporting.log
 ```
 
 
 More details about `htrun` are [here](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests#testing-mbed-os-examples).
-

--- a/tests/crash-reporting.log
+++ b/tests/crash-reporting.log
@@ -6,28 +6,28 @@ Mbed-OS crash reporting test: main\(\)
 
 Successfully read reboot info ==>
 
-  error status: 0x[0-9a-fA-F]{8}
-  error value: 0x[0-9a-fA-F]{8}
-  error address: 0x[0-9a-fA-F]{8}
-  error reboot count: 0x[0-9a-fA-F]{8}
-  error crc: 0x[0-9a-fA-F]{8}
+  error status: 0x[0-9a-fA-F]+
+  error value: 0x[0-9a-fA-F]+
+  error address: 0x[0-9a-fA-F]+
+  error reboot count: 0x[0-9a-fA-F]+
+  error crc: 0x[0-9a-fA-F]+
 
 Crash Report data captured:
-\[0\]: 0x[0-9a-fA-F]{8}
-\[1\]: 0x[0-9a-fA-F]{8}
-\[2\]: 0x[0-9a-fA-F]{8}
-\[3\]: 0x[0-9a-fA-F]{8}
-\[4\]: 0x[0-9a-fA-F]{8}
-\[5\]: 0x[0-9a-fA-F]{8}
-\[6\]: 0x[0-9a-fA-F]{8}
-\[7\]: 0x[0-9a-fA-F]{8}
-\[8\]: 0x[0-9a-fA-F]{8}
-\[9\]: 0x[0-9a-fA-F]{8}
-\[10\]: 0x[0-9a-fA-F]{8}
-\[11\]: 0x[0-9a-fA-F]{8}
-\[12\]: 0x[0-9a-fA-F]{8}
-\[13\]: 0x[0-9a-fA-F]{8}
-\[14\]: 0x[0-9a-fA-F]{8}
-\[15\]: 0x[0-9a-fA-F]{8}
+\[0\]: 0x[0-9a-fA-F]+
+\[1\]: 0x[0-9a-fA-F]+
+\[2\]: 0x[0-9a-fA-F]+
+\[3\]: 0x[0-9a-fA-F]+
+\[4\]: 0x[0-9a-fA-F]+
+\[5\]: 0x[0-9a-fA-F]+
+\[6\]: 0x[0-9a-fA-F]+
+\[7\]: 0x[0-9a-fA-F]+
+\[8\]: 0x[0-9a-fA-F]+
+\[9\]: 0x[0-9a-fA-F]+
+\[10\]: 0x[0-9a-fA-F]+
+\[11\]: 0x[0-9a-fA-F]+
+\[12\]: 0x[0-9a-fA-F]+
+\[13\]: 0x[0-9a-fA-F]+
+\[14\]: 0x[0-9a-fA-F]+
+\[15\]: 0x[0-9a-fA-F]+
 
 Mbed-OS crash reporting test completed


### PR DESCRIPTION
Remove expectation for width format sub-specifier on `printf()` calls to
work as Minimal-printf does not support it.