### PR TITLE
Increase baud rate to 115200

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Second run:
     $ mbed compile -m <TARGET> -t <TOOLCHAIN> --flash
     ```
 
-(Note: You can use the Mbed CLI command-line option `--sterm` to open a serial terminal after flashing.)
+(Note: You can use the Mbed CLI command-line option `--sterm --baudrate 115200` to open a serial terminal after flashing.)
 
 Your PC may take a few minutes to compile your code.
 

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,7 +1,8 @@
 {
     "target_overrides": {
         "*": {
-            "platform.stdio-convert-newlines": 1
+            "platform.stdio-convert-newlines": 1,
+            "platform.stdio-baud-rate": 115200
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ARMmbed/mbed-os/issues/14535

The full log of this example looks like (note `1st run` and `2nd run`):
<details>
  <summary>Code</summary>

```                                                                                                                                                 
[1618323909.87][GLRM][INF] waiting 1.00 sec after reset                                                                                                                                                           
[1618323910.93][GLRM][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed                                                                                                                                               
[1618323910.93][CONN][WRN] skipping __sync packet (specified with --sync=0)                                                                                                                                       
[1618323910.93][CONN][RXD]                                                                                                                                                                                        
[1618323910.93][CONN][RXD] This is the crash reporting Mbed OS example                                                                                                                                            
[1618323910.93][CONN][RXD] 1st run: Inject the fault exception                                                                                                                                                    
[1618323910.93][CONN][RXD]                                                                                                                                                                                        
[1618323910.93][CONN][RXD] ++ MbedOS Fault Handler ++                                                                                                                                                             
[1618323910.93][CONN][RXD]                                                                                                                                                                                        
[1618323910.93][CONN][RXD] FaultType: HardFault                                                                                                                                                                   
[1618323910.93][CONN][RXD]                                                                                                                                                                                        
[1618323910.94][CONN][RXD] Context:                                                                                                                                                                               
[1618323910.94][CONN][RXD] R   0: 000085CC                                                                                                                                                                        
[1618323910.94][CONN][RXD] R   1: 00000000                                                                                                                                                                        
[1618323910.94][CONN][RXD] R   2: E000ED00                                                                                                                                                                        
[1618323910.94][CONN][RXD] R   3: 0000AAA3                                                                                                                                                                        
[1618323910.94][CONN][RXD] R   4: 00000000                                                                                                                                                                        
[1618323910.94][CONN][RXD] R   5: 00000000                                                                                                                                                                        
[1618323910.94][CONN][RXD] R   6: 00000000                                                                                                                                                                        
[1618323910.94][CONN][RXD] R   7: 00000000                                                                                                                                                                        
[1618323910.94][CONN][RXD] R   8: 00000000                                                                                                                                                                        
[1618323910.94][CONN][RXD] R   9: 00000000                                                                                                                                                                        
[1618323910.94][CONN][RXD] R  10: 00000000                                                                                                                                                                        
[1618323910.94][CONN][RXD] R  11: 00000000                                                                                                                                                                        
[1618323910.94][CONN][RXD] R  12: FFFFFFFF                                                                                                                                                                        
[1618323910.94][CONN][RXD] SP   : 20002DD8                                                                                                                                                                        
[1618323910.94][CONN][RXD] LR   : 00000E77                                                                                                                                                                        
[1618323910.94][CONN][RXD] PC   : 00000DE4                                                                                                                                                                        
[1618323910.94][CONN][RXD] xPSR : 010F0000                                                                                                                                                                        
[1618323910.94][CONN][RXD] PSP  : 20002DB8                                                                                                                                                                        
[1618323910.94][CONN][RXD] MSP  : 2002FFC0                                                                                                                                                                        
[1618323910.94][CONN][RXD] CPUID: 410FC241                                                                                                                                                                        
[1618323910.94][CONN][RXD] HFSR : 40000000                                                               
[1618323910.94][CONN][RXD] MMFSR: 00000000                                                               
[1618323910.94][CONN][RXD] BFSR : 00000000                                                               
[1618323910.94][CONN][RXD] UFSR : 00000100                                                               
[1618323910.94][CONN][RXD] DFSR : 00000008                                                                                                                                                                        
[1618323910.94][CONN][RXD] AFSR : 00000000
[1618323910.94][CONN][RXD] Mode : Thread
[1618323910.94][CONN][RXD] Priv : Privileged
[1618323910.94][CONN][RXD] Stack: PSP
[1618323910.94][CONN][RXD] 
[1618323910.94][CONN][RXD] -- MbedOS Fault Handler --
[1618323910.94][CONN][RXD] 
[1618323910.94][CONN][RXD] 
[1618323910.94][CONN][RXD] 
[1618323910.94][CONN][RXD] ++ MbedOS Error Info ++
[1618323910.94][CONN][RXD] Error Status: 0x80FF013D Code: 317 Module: 255
[1618323910.94][CONN][RXD] Error Message: Fault exception
[1618323910.94][CONN][RXD] Location: 0xDE4
[1618323910.94][CONN][RXD] Error Value: 0x1FFF0400
[1618323910.94][CONN][RXD] Current Thread: main Id: 0x200012D0 Entry: 0x2689 StackSize: 0x1000 StackMem: 0x20001E00 SP: 0x20002DD8 
[1618323910.94][CONN][RXD] For more info, visit: https://mbed.com/s/error?error=0x80FF013D&tgt=TARGET_NAME
[1618323910.94][CONN][RXD] -- MbedOS Error Info --
[1618323910.94][CONN][RXD] 
[1618323910.94][CONN][RXD] = System will be rebooted due to a fatal error =
[1618323910.94][CONN][RXD] = Reboot count(=1) reached maximum, system will halt after rebooting =
[1618323910.94][CONN][RXD] 
[1618323910.94][CONN][RXD] (before main) mbed_error_reboot_callback invoked with the following error context:
[1618323910.94][CONN][RXD]     Status      : 0x80FF013D
[1618323910.94][CONN][RXD]     Value       : 0x1FFF0400
[1618323910.94][CONN][RXD]     Address     : 0xDE4
[1618323910.94][CONN][RXD]     Reboot count: 0x1
[1618323910.94][CONN][RXD]     CRC         : 0xC03AE251
[1618323910.94][CONN][RXD] 
[1618323910.94][CONN][RXD] This is the crash reporting Mbed OS example
[1618323910.94][CONN][RXD] 2nd run: Retrieve the fault context using mbed_get_reboot_fault_context
[1618323910.94][CONN][RXD]     R0   : 0x85CC
[1618323910.94][CONN][RXD]     R1   : 0x0
[1618323910.94][CONN][RXD]     R2   : 0xE000ED00
[1618323910.94][CONN][RXD]     R3   : 0xAAA3
[1618323910.94][CONN][RXD]     R4   : 0x0
[1618323910.94][CONN][RXD]     R5   : 0x0
[1618323910.94][CONN][RXD]     R6   : 0x0
[1618323910.94][CONN][RXD]     R7   : 0x0
[1618323910.94][CONN][RXD]     R8   : 0x0
[1618323910.94][CONN][RXD]     R9   : 0x0
[1618323910.94][CONN][RXD]     R10   : 0x0
[1618323910.94][CONN][RXD]     R11   : 0x0
[1618323910.94][CONN][RXD]     R12   : 0xFFFFFFFF
[1618323910.94][CONN][RXD]     SP   : 0x20002DD8
[1618323910.94][CONN][RXD]     LR   : 0xE77
[1618323910.94][CONN][RXD]     PC   : 0xDE4
[1618323910.94][CONN][RXD]     xPSR : 0x10F0000
[1618323910.94][CONN][RXD]     PSP  : 0x20002DB8
[1618323910.94][CONN][RXD]     MSP  : 0x2002FFC0
[1618323910.94][CONN][RXD] 
[1618323910.94][CONN][RXD] Mbed OS crash reporting example completed
```
</details>

When running the example at 9600 baud in CI, a huge part of the serial output is lost, and we're left with:
<details>
  <summary>Code</summary>

```                                  
[1618323638.28][GLRM][INF] waiting 1.00 sec after reset                                                                                                                                                           
[1618323639.34][GLRM][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed
[1618323639.34][CONN][WRN] skipping __sync packet (specified with --sync=0)
[1618323639.34][CONN][RXD] ror context:                                                                                                                                                                           
[1618323639.34][CONN][RXD]     Status                                                                    
[1618323639.34][CONN][RXD]        
[1618323639.34][CONN][RXD] (before main) mbed_error_reboot_callback invoked with the following error context:                          
[1618323639.34][CONN][RXD]     Status      : 0x80FF013D
[1618323639.34][CONN][RXD]     Value       : 0x1FFF0400
[1618323639.34][CONN][RXD]     Address     : 0xDE4
[1618323639.34][CONN][RXD]     Reboot count: 0x1                                                                                                                                                                  
[1618323639.34][CONN][RXD]     CRC         : 0xC03AE251
[1618323639.35][CONN][RXD]                                                                                                                                                                                        
[1618323639.35][CONN][RXD] This is the crash reporting Mbed OS example
[1618323639.35][CONN][RXD] 2nd run: Retrieve the fault context using mbed_get_reboot_fault_context                                                                                                                
[1618323639.35][CONN][RXD]     R0   : 0x85CC                                                             
[1618323639.35][CONN][RXD]     R1   : 0x0                                                                                                                                                                         
[1618323639.35][CONN][RXD]     R2   : 0xE000ED00  
[1618323639.35][CONN][RXD]     R3   : 0xAAA3                                                                                                                                                                      
[1618323639.35][CONN][RXD]     R4   : 0x0
[1618323639.35][CONN][RXD]     R5   : 0x0                                                                                                                                                                         
[1618323639.35][CONN][RXD]     R6   : 0x0
[1618323639.35][CONN][RXD]     R7   : 0x0
[1618323639.35][CONN][RXD]     R8   : 0x0                                                                
[1618323639.35][CONN][RXD]     R9   : 0x0
[1618323639.35][CONN][RXD]     R10   : 0x0
[1618323639.35][CONN][RXD]     R11   : 0x0
[1618323639.35][CONN][RXD]     R12   : 0xFFFFFFFF
[1618323639.35][CONN][RXD]     SP   : 0x20002DD8
[1618323639.35][CONN][RXD]     LR   : 0xE77
[1618323639.35][CONN][RXD]     PC   : 0xDE4
[1618323639.35][CONN][RXD]     xPSR : 0x10F0000
[1618323639.35][CONN][RXD]     PSP  : 0x20002DB8
[1618323639.35][CONN][RXD]     MSP  : 0x2002FFC0
[1618323639.35][CONN][RXD] 
[1618323639.35][CONN][RXD] Mbed OS crash reporting example completed
```
</details>

This issue only happens in CI, and the "cut-off" position is random. This causes the example to fail randomly in CI, depending on whether `= System will be rebooted due to a fatal error =` expected by [crash-reporting.log](https://github.com/ARMmbed/mbed-os-example-crash-reporting/blob/mbed-os-6.9.0/tests/crash-reporting.log) happens to be lost or not.

This problem doesn't happen on a local board when using `mbedgt` to run the example & compare the log.

Increasing the serial baud rate resolves the issue in CI.