### PR TITLE
Fix Travis and add instructions for Mbed CLI 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,9 @@ matrix:
         - pip install "Jinja2>=2.10.1,<2.11"
         - pip install "intelhex>=1.3,<=2.2.1"
       script:
-        - mbedtools checkout
-        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
-        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools deploy
+        - echo mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 
     - <<: *cmake-build-test

--- a/README.md
+++ b/README.md
@@ -5,11 +5,21 @@ This example demonstrates how Mbed OS crash reporting works on an Mbed OS Enable
 
 You can find more information about the crash reporting APIs in the [documentation](https://os.mbed.com/docs/mbed-os/latest/apis/error-handling.html#crash-reporting-and-auto-reboot).
 
-You can build this project with all supported [Mbed OS build tools](https://os.mbed.com/docs/mbed-os/latest/tools/index.html). However, this example project specifically refers to the command-line interface tool [Arm Mbed CLI](https://github.com/ARMmbed/mbed-cli#installing-mbed-cli).
+You can build the project with all supported [Mbed OS build tools](https://os.mbed.com/docs/mbed-os/latest/tools/index.html). However, this example project specifically refers to the command-line interface tools, [Arm Mbed CLI 1](https://github.com/ARMmbed/mbed-cli#installing-mbed-cli) and [Mbed CLI 2](https://github.com/ARMmbed/mbed-tools#installation).
 
-1. Install Mbed CLI.
+## Mbed OS build tools
+
+### Mbed CLI 2
+Starting with version 6.5, Mbed OS uses Mbed CLI 2. It uses Ninja as a build system, and CMake to generate the build environment and manage the build process in a compiler-independent manner. If you are working with Mbed OS version prior to 6.5 then check the section [Mbed CLI 1](#mbed-cli-1).
+1. [Install Mbed CLI 2](https://os.mbed.com/docs/mbed-os/latest/build-tools/install-or-upgrade.html).
+1. From the command-line, import the example: `mbed-tools import mbed-os-example-crash-reporting`
+1. Change the current directory to where the project was imported.
+
+### Mbed CLI 1
+1. [Install Mbed CLI 1](https://os.mbed.com/docs/mbed-os/latest/quick-start/offline-with-mbed-cli.html).
 1. From the command-line, import the example: `mbed import mbed-os-example-crash-reporting`
 1. Change the current directory to where the project was imported.
+
 
 ## Application functionality
 
@@ -45,23 +55,46 @@ Second run:
 1. Connect a USB cable between the USB port on the target and the host computer.
 1. Run this command to build the example project and program the microcontroller flash memory:
 
+    * Mbed CLI 2
+
     ```bash
-    $ mbed compile -m <TARGET> -t <TOOLCHAIN> --flash --sterm
+    $ mbed-tools compile -m <TARGET> -t <TOOLCHAIN> --flash
     ```
 
-(Note: You can use the Mbed CLI command-line option "--sterm" to open a serial terminal after flashing.)
+    * Mbed CLI 1
+
+    ```bash
+    $ mbed compile -m <TARGET> -t <TOOLCHAIN> --flash
+    ```
+
+(Note: You can use the Mbed CLI command-line option `--sterm` to open a serial terminal after flashing.)
 
 Your PC may take a few minutes to compile your code.
 
-The binary is located at `./BUILD/<TARGET>/<TOOLCHAIN>/mbed-os-example-crash-reporting.bin`.
+The binary is located at:
 
-Alternatively, you can manually copy the binary to the target, which gets mounted on the host computer through USB.
+* **Mbed CLI 2** -
+  `./cmake_build/<TARGET>/develop/<TOOLCHAIN>/mbed-os-example-crash-reporting.bin`
 
-Depending on the target, you can build the example project with the `GCC_ARM`, `ARM` or `IAR` toolchain. After installing Arm Mbed CLI, run the command below to determine which toolchain supports your target:
+* **Mbed CLI 1** - `./BUILD/<TARGET>/<TOOLCHAIN>/mbed-os-example-crash-reporting.bin`.
 
-```bash
-$ mbed compile -S
-```
+You can manually copy the binary to the target, which gets mounted on the host
+computer through USB, rather than using the `--flash` option.
+
+You can also open a serial terminal separately, rather than using the `--sterm`
+option, with the following command:
+
+* Mbed CLI 2
+    ```bash
+    $ mbed-tools sterm
+    ```
+
+* Mbed CLI 1
+    ```bash
+    $ mbed sterm
+    ```
+
+Depending on the target, you can build the example project with the `GCC_ARM` or `ARM` toolchain.
 
 ## Expected output
 


### PR DESCRIPTION
This PR
* Updates mbed-tools commands in `.travis.yml`
* Adds instructions for Mbed CLI 2 to README

Fixes #66

This is required by #65 